### PR TITLE
remove rostest from top level find_package

### DIFF
--- a/tts/CMakeLists.txt
+++ b/tts/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(tts)
 
-find_package(catkin REQUIRED COMPONENTS actionlib_msgs message_generation rospy rosunit rostest std_msgs sound_play)
+find_package(catkin REQUIRED COMPONENTS actionlib_msgs message_generation rospy rosunit std_msgs sound_play)
 
 catkin_python_setup()
 


### PR DESCRIPTION
This should resolve the build error here:
http://build.ros.org/view/Kbin_uxv8_uXv8/job/Kbin_uxv8_uXv8__tts__ubuntu_xenial_arm64__binary/1/console

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
