### PR TITLE
no assert_called() for older versions of mock

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,6 @@ This node will require the following AWS account IAM role permissions:
 
 #### Build from Source
 
-If you test this package on versions of Ubuntu older than 18.x (16.04 for example), please upgrade `mock` to the latest version by using `pip`.
-    
-    sudo apt-get python-pip
-    pip install -U mock requests
-    
 Create a ROS workspace and a source directory
 
     mkdir -p ~/ros-workspace/src

--- a/tts/package.xml
+++ b/tts/package.xml
@@ -35,4 +35,5 @@
 
   <test_depend>rosunit</test_depend>
   <test_depend>rostest</test_depend>
+  <test_depend>python-mock</test_depend>
 </package>

--- a/tts/test/test_unit_polly.py
+++ b/tts/test/test_unit_polly.py
@@ -45,7 +45,7 @@ class TestPolly(unittest.TestCase):
         from tts.amazonpolly import AmazonPolly
         AmazonPolly()
 
-        boto3_session_class_mock.assert_called()
+        self.assertGreater(boto3_session_class_mock.call_count, 0)
         boto3_session_class_mock.return_value.client.assert_called_with('polly')
 
     @patch('tts.amazonpolly.Session')
@@ -53,7 +53,7 @@ class TestPolly(unittest.TestCase):
         from tts.amazonpolly import AmazonPolly
         polly = AmazonPolly()
 
-        boto3_session_class_mock.assert_called()
+        self.assertGreater(boto3_session_class_mock.call_count, 0)
         boto3_session_class_mock.return_value.client.assert_called_with('polly')
 
         self.assertEqual('text', polly.default_text_type)
@@ -87,7 +87,7 @@ class TestPolly(unittest.TestCase):
         from tts.amazonpolly import AmazonPolly
         polly_under_test = AmazonPolly()
 
-        boto3_session_class_mock.assert_called()
+        self.assertGreater(boto3_session_class_mock.call_count, 0)
         boto3_session_obj_mock.client.assert_called_with('polly')
 
         res = polly_under_test.synthesize(text='hello')
@@ -139,7 +139,7 @@ class TestPolly(unittest.TestCase):
         from tts.amazonpolly import AmazonPolly
         polly_under_test = AmazonPolly()
 
-        boto3_session_class_mock.assert_called()
+        self.assertGreater(boto3_session_class_mock.call_count, 0)
         boto3_session_obj_mock.client.assert_called_with('polly')
 
         res = polly_under_test.synthesize(text='hello')
@@ -169,7 +169,7 @@ class TestPolly(unittest.TestCase):
         with patch.object(sys, 'argv', ['polly_node.py', '-n', 'polly-node']):
             from tts import amazonpolly
             amazonpolly.main()
-            amazon_polly_class_mock.assert_called()
+            self.assertGreater(amazon_polly_class_mock.call_count, 0)
             amazon_polly_class_mock.return_value.start.assert_called_with(node_name='polly-node', service_name='polly')
 
 

--- a/tts/test/test_unit_synthesizer.py
+++ b/tts/test/test_unit_synthesizer.py
@@ -70,7 +70,7 @@ class TestSynthesizer(unittest.TestCase):
         request = SynthesizerRequest(text=test_text, metadata=test_metadata)
         response = speech_synthesizer._node_request_handler(request)
 
-        polly_class_mock.assert_called()
+        self.assertGreater(polly_class_mock.call_count, 0)
         polly_obj_mock.synthesize.assert_called_with(**expected_polly_synthesize_args)
 
         self.assertEqual(response.result, polly_obj_mock.synthesize.return_value.result)
@@ -131,7 +131,7 @@ class TestSynthesizer(unittest.TestCase):
             from tts import synthesizer
             synthesizer.main()
             speech_synthesizer_class_mock.assert_called_with(engine='POLLY_LIBRARY')
-            speech_synthesizer_class_mock.return_value.start.assert_called()
+            self.assertGreater(speech_synthesizer_class_mock.return_value.start.call_count, 0)
 
     @patch('tts.synthesizer.SpeechSynthesizer')
     def test_cli_engine_dispatching_3(self, speech_synthesizer_class_mock):
@@ -140,7 +140,7 @@ class TestSynthesizer(unittest.TestCase):
             from tts import synthesizer
             synthesizer.main()
             speech_synthesizer_class_mock.assert_called_with(engine='POLLY_SERVICE', polly_service_name='apolly')
-            speech_synthesizer_class_mock.return_value.start.assert_called()
+            self.assertGreater(speech_synthesizer_class_mock.return_value.start.call_count, 0)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
*fix travis failure*

The CI failure was caused by the lack of `assert_called()` in older versions of `python-mock`. The fix replaced the use of `assert_called` with a comparison between `call_count` and 0.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
