### PR TITLE
Modifying build instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ The source code is released under an [Apache 2.0].
 
 ### Supported ROS Distributions
 - Kinetic
-- Lunar
 - Melodic
 
 
@@ -37,27 +36,36 @@ You will need to create an AWS Account and configure the credentials to be able 
 This node will require the following AWS account IAM role permissions:
 - `polly:SynthesizeSpeech`
 
-### Build and Test
+### Binaries
+On Ubuntu you can install the latest version of this package using the following command
 
-#### Build from Source
+        sudo apt-get update
+        sudo apt-get install -y ros-kinetic-tts
 
-Create a ROS workspace and a source directory
+### Building from Source
+
+To build from source you'll need to create a new workspace, clone and checkout the latest release branch of this repository, install all the dependencies, and compile. If you need the latest development features you can clone from the `master` branch instead of the latest release branch. While we guarantee the release branches are stable, __the `master` should be considered to have an unstable build__ due to ongoing development. 
+
+- Create a ROS workspace and a source directory
 
     mkdir -p ~/ros-workspace/src
 
-To install from source, clone the latest version from master branch and compile the package
+- Clone the package into the source directory . 
 
-- Clone the package into the source directory
+_Note: Replace __`{MAJOR.VERSION}`__ below with the latest major version number to get the latest release branch._
 
-        cd ~/ros-workspace/src 
-        git clone https://github.com/aws-robotics/tts-ros1.git
+        cd ~/ros-workspace/src
+        git clone https://github.com/aws-robotics/tts-ros1.git -b release-v{MAJOR.VERSION}
 
 - Install dependencies
 
-        cd ~/ros-workspace && sudo apt-get update 
+        cd ~/ros-workspace 
+        sudo apt-get update && rosdep update
         rosdep install --from-paths src --ignore-src -r -y
+        
+_Note: If building the master branch instead of a release branch you may need to also checkout and build the master branches of the packages this package depends on._
 
-- Install the packages
+- Build the packages
 
         cd ~/ros-workspace && colcon build
 


### PR DESCRIPTION
The current build instructions tell you to git clone this repository and all the dependent repositories from the master branch. However, we want to consider the master branch unstable for development and instruct users to build from source using the release branches if they don't need the cutting edge features.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
