### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ _Note: If building the master branch instead of a release branch you may need to
 
         colcon test --packages-select tts && colcon test-result --all
 
-#### Test on Containers/Virtual Machines
+### Testing in Containers/Virtual Machines
 
 Even if your container or virtual machine does not have audio device, you can still test TTS by leveraging an audio server.
 


### PR DESCRIPTION
The formatting for the `Testing on Containers/Virtual Machines` header was confusing as the font looks identical to its following three subsections, so it wasn't obvious that those subsections belonged to the testing section. I changed the header from 4 hash marks to 3 hash marks. This also makes it obvious that this section is not part of the `Building from Source` section above, which also has 3 hash marks.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
