### PR TITLE
Add workaround for soundplay file limit

### DIFF
--- a/tts/scripts/tts_node.py
+++ b/tts/scripts/tts_node.py
@@ -52,6 +52,7 @@ read some instructions and immediately get ready for any input.
 
 import json
 import os
+import tempfile
 
 import actionlib
 import rospy
@@ -61,7 +62,7 @@ from tts.srv import Synthesizer
 from sound_play.libsoundplay import SoundClient
 
 # Output files will be symlinked to this path
-SOUND_FILE_PATH = os.path.join(os.sep, 'tmp', 'tts_sound_file')
+SOUND_FILE_PATH = os.path.join(tempfile.gettempdir(), 'tts_sound_file')
 
 def play(filename):
     """plays the wav or ogg file using sound_play"""
@@ -110,7 +111,8 @@ def do_speak(goal):
         # to the soundplay node is a workaround.
         # See: https://github.com/ros-drivers/audio_common/issues/125
         sym_link_path = os.path.abspath(SOUND_FILE_PATH)
-        os.remove(sym_link_path)
+        if os.path.lexists(sym_link_path):
+            os.remove(sym_link_path)
         rospy.loginfo('Will play {}'.format(audio_file))
         rospy.loginfo('Symlinking {} to {}'.format(audio_file, sym_link_path))
         os.symlink(audio_file, sym_link_path)

--- a/tts/scripts/tts_node.py
+++ b/tts/scripts/tts_node.py
@@ -51,6 +51,7 @@ read some instructions and immediately get ready for any input.
 """
 
 import json
+import os
 
 import actionlib
 import rospy
@@ -59,6 +60,8 @@ from tts.srv import Synthesizer
 
 from sound_play.libsoundplay import SoundClient
 
+# Output files will be symlinked to this path
+SOUND_FILE_PATH = os.path.join(os.sep, 'tmp', 'tts_sound_file')
 
 def play(filename):
     """plays the wav or ogg file using sound_play"""
@@ -102,8 +105,16 @@ def do_speak(goal):
 
     if 'Audio File' in r:
         audio_file = r['Audio File']
+        # Soundplay cannot handle more than 32 different file paths.
+        # Creating a symlink to the polly output and then passing that to
+        # to the soundplay node is a workaround.
+        # See: https://github.com/ros-drivers/audio_common/issues/125
+        sym_link_path = os.path.abspath(SOUND_FILE_PATH)
+        os.remove(sym_link_path)
         rospy.loginfo('Will play {}'.format(audio_file))
-        play(audio_file)
+        rospy.loginfo('Symlinking {} to {}'.format(audio_file, sym_link_path))
+        os.symlink(audio_file, sym_link_path)
+        play(sym_link_path)
         result = audio_file
 
     if 'Exception' in r:

--- a/tts/scripts/tts_node.py
+++ b/tts/scripts/tts_node.py
@@ -114,7 +114,7 @@ def do_speak(goal):
         if os.path.lexists(sym_link_path):
             os.remove(sym_link_path)
         rospy.loginfo('Will play {}'.format(audio_file))
-        rospy.loginfo('Symlinking {} to {}'.format(audio_file, sym_link_path))
+        rospy.logdebug('Symlinking {} to {}'.format(audio_file, sym_link_path))
         os.symlink(audio_file, sym_link_path)
         play(sym_link_path)
         result = audio_file


### PR DESCRIPTION
Signed-off-by: ryanewel <ryanewel@amazon.com>

*Issue #, if available:*
https://github.com/aws-robotics/tts-ros1/issues/26
*Description of changes:*
Instead of passing unique file names to soundplay node this change creates a symlink with a constant name to the output file.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
