### PR TITLE
Revert "Add workaround for soundplay file limit (#34)"

### DIFF
--- a/tts/scripts/tts_node.py
+++ b/tts/scripts/tts_node.py
@@ -51,8 +51,6 @@ read some instructions and immediately get ready for any input.
 """
 
 import json
-import os
-import tempfile
 
 import actionlib
 import rospy
@@ -61,8 +59,6 @@ from tts.srv import Synthesizer
 
 from sound_play.libsoundplay import SoundClient
 
-# Output files will be symlinked to this path
-SOUND_FILE_PATH = os.path.join(tempfile.gettempdir(), 'tts_sound_file')
 
 def play(filename):
     """plays the wav or ogg file using sound_play"""
@@ -106,17 +102,8 @@ def do_speak(goal):
 
     if 'Audio File' in r:
         audio_file = r['Audio File']
-        # Soundplay cannot handle more than 32 different file paths.
-        # Creating a symlink to the polly output and then passing that to
-        # to the soundplay node is a workaround.
-        # See: https://github.com/ros-drivers/audio_common/issues/125
-        sym_link_path = os.path.abspath(SOUND_FILE_PATH)
-        if os.path.lexists(sym_link_path):
-            os.remove(sym_link_path)
         rospy.loginfo('Will play {}'.format(audio_file))
-        rospy.logdebug('Symlinking {} to {}'.format(audio_file, sym_link_path))
-        os.symlink(audio_file, sym_link_path)
-        play(sym_link_path)
+        play(audio_file)
         result = audio_file
 
     if 'Exception' in r:


### PR DESCRIPTION
This reverts commit e26cda14dbc51075152d8dd221be64d764a36e8e.

See this comment for bug report:
https://github.com/aws-robotics/tts-ros1/pull/34#issuecomment-525521776


The first commit was inadequately tested and introduced a bug so that only one sound could be played (although it could be played as many times as you want). It looks like sound_play may be cacheing the contents of the file and not re-reading it each time. 

It seems like a better user experience to get 32 sounds than just 1 so reverting that change.

Confirmed that after reverting this commit 32 different sounds could be played. Hanging behavior has returned though.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
