### PR TITLE
Remove exporting tts library

### DIFF
--- a/tts/CMakeLists.txt
+++ b/tts/CMakeLists.txt
@@ -27,7 +27,6 @@ generate_messages(DEPENDENCIES actionlib_msgs std_msgs)
 ## CATKIN_DEPENDS: catkin_packages dependent projects also need
 ## DEPENDS: system dependencies of this project that dependent projects also need
 catkin_package(
-  LIBRARIES tts
   CATKIN_DEPENDS actionlib_msgs message_runtime rospy std_msgs
 )
 


### PR DESCRIPTION
*Issue #40 : Linking issue with other ROS packages*

*Description of changes: Remove exporting `tts` library which is never created to allow linking with other ROS packages, e.g. to get the custom messages.*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
